### PR TITLE
Accept berglas prefix in addition of gs prefix for handling secret.

### DIFF
--- a/main.go
+++ b/main.go
@@ -614,10 +614,11 @@ func readData(s string) ([]byte, error) {
 // parseRef parses a secret ref into a bucket, secret path, and any errors.
 func parseRef(s string) (string, string, error) {
 	s = strings.TrimPrefix(s, "gs://")
+	s = strings.TrimPrefix(s, "berglas://")
 
 	ss := strings.SplitN(s, "/", 2)
 	if len(ss) < 2 {
-		return "", "", errors.Errorf("secret does not match format gs://<bucket>/<secret>: %s", s)
+		return "", "", errors.Errorf("secret does not match format gs://<bucket>/<secret> or the format berglas://<bucket>/<secret>: %s", s)
 	}
 
 	return ss[0], ss[1], nil

--- a/main_test.go
+++ b/main_test.go
@@ -118,6 +118,18 @@ func Test_parseRef(t *testing.T) {
 			"foo", "bar/baz/bacon",
 			false,
 		},
+		{
+			"berglas-prefix",
+			"berglas://foo/bar",
+			"foo", "bar",
+			false,
+		},
+		{
+			"berglas + folder",
+			"berglas://foo/bar/baz/bacon",
+			"foo", "bar/baz/bacon",
+			false,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
When I want to access to a secret, I have to copy paste my env var existing in the my config file, remove berglas prefix.
For solving that, I add the capability to trim either gs:// or berglas://. This feature is available on all commands which require a `${BUCKET_ID}`. I didn't know how to well improved the documentation for that. So I didn't touch it. The current blur let me guess that berglas:// was valid. I choose to let this blur because both are now possible.