### PR TITLE
Update starting value to match expected value from `berglas bootstrap`

### DIFF
--- a/examples/cloudbuild/README.md
+++ b/examples/cloudbuild/README.md
@@ -24,7 +24,7 @@ a shared volume mount to pass along secrets.
     ```text
     export PROJECT_ID=my-project
     export BUCKET_ID=my-bucket
-    export KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/my-keyring/cryptoKeys/my-key
+    export KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/berglas/cryptoKeys/berglas-key
     ```
 
 1. Create two secrets using the `berglas` CLI (see README for installation

--- a/examples/cloudfunctions/go/README.md
+++ b/examples/cloudfunctions/go/README.md
@@ -14,7 +14,7 @@ continuing!
     ```text
     export PROJECT_ID=my-project
     export BUCKET_ID=my-bucket
-    export KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/my-keyring/cryptoKeys/my-key
+    export KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/berglas/cryptoKeys/berglas-key
     ```
 
 1. Create two secrets using the `berglas` CLI (see README for installation

--- a/examples/cloudrun/go/README.md
+++ b/examples/cloudrun/go/README.md
@@ -13,7 +13,7 @@ Storage bucket, and Cloud KMS key.
     ```text
     export PROJECT_ID=my-project
     export BUCKET_ID=my-bucket
-    export KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/my-keyring/cryptoKeys/my-key
+    export KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/berglas/cryptoKeys/berglas-key
     ```
 
 1. Create two secrets using the `berglas` CLI (see README for installation

--- a/examples/cloudrun/python/README.md
+++ b/examples/cloudrun/python/README.md
@@ -13,7 +13,7 @@ Storage bucket, and Cloud KMS key.
     ```text
     export PROJECT_ID=my-project
     export BUCKET_ID=my-bucket
-    export KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/my-keyring/cryptoKeys/my-key
+    export KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/berglas/cryptoKeys/berglas-key
     ```
 
 1. Create two secrets using the `berglas` CLI (see README for installation

--- a/examples/cloudrun/ruby/README.md
+++ b/examples/cloudrun/ruby/README.md
@@ -14,7 +14,7 @@ continuing!
     ```text
     export PROJECT_ID=my-project
     export BUCKET_ID=my-bucket
-    export KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/my-keyring/cryptoKeys/my-key
+    export KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/berglas/cryptoKeys/berglas-key
     ```
 
 1. Create two secrets using the `berglas` CLI (see README for installation

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -75,7 +75,7 @@ On Google Cloud, it is strongly recommended that you have a dedicated service ac
     ```text
     PROJECT_ID=berglas-test
     BUCKET_ID=berglas-test-secrets
-    KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/my-keyring/cryptoKeys/my-key
+    KMS_KEY=projects/${PROJECT_ID}/locations/global/keyRings/berglas/cryptoKeys/berglas-key
     ```
 
 1. Create a service account:


### PR DESCRIPTION
This change ensure a more fluid experience going from the main README to any specific example. 

The output from `berglas bootstrap` states the KMS key created is: 

```
KMS key: projects/[PROJECT]/locations/global/keyRings/berglas/cryptoKeys/berglas-key
```
so the `export KMS_KEY` default for all examples has been updated to reflect this. 