### PR TITLE
Allow accessing a specific generation from env vars

### DIFF
--- a/doc/reference-syntax.md
+++ b/doc/reference-syntax.md
@@ -7,7 +7,7 @@ parse these strings at the library level too.
 ## Syntax
 
 ```text
-berglas://[BUCKET]/[SECRET]?[OPTIONS]
+berglas://[BUCKET]/[SECRET]?[OPTIONS]#[GENERATION]
 ```
 
 - `BUCKET` - name of the Cloud Storage bucket where the secret is stored
@@ -15,6 +15,8 @@ berglas://[BUCKET]/[SECRET]?[OPTIONS]
 - `SECRET` - name of the secret in the Cloud Storage bucket
 
 - `OPTIONS` - options specified as URL query parameters
+
+- `GENERATION` - secret generation to access specified as URL fragment. Defaults to latest.
 
 ### Options
 
@@ -39,4 +41,10 @@ Read a secret into a tempfile:
 
 ```text
 berglas://my-bucket/path/to/my-secret?destination=tempfile
+```
+
+Read a specific generation of a secret:
+
+```text
+berglas://my-bucket/path/to/my-secret#1563925173373377
 ```

--- a/pkg/berglas/reference.go
+++ b/pkg/berglas/reference.go
@@ -17,6 +17,7 @@ package berglas
 import (
 	"io/ioutil"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -29,9 +30,10 @@ const (
 
 // Reference is a parsed berglas reference.
 type Reference struct {
-	bucket   string
-	object   string
-	filepath string
+	bucket     string
+	object     string
+	generation int64
+	filepath   string
 }
 
 // Bucket is the storage bucket where the secret lives.
@@ -47,6 +49,11 @@ func (r *Reference) Object() string {
 // Filepath is the disk to write the reference, if any.
 func (r *Reference) Filepath() string {
 	return r.filepath
+}
+
+// Generation is the secret generation, if any.
+func (r *Reference) Generation() int64 {
+	return r.generation
 }
 
 // IsReference returns true if the given string looks like a berglas reference,
@@ -85,6 +92,12 @@ func ParseReference(s string) (*Reference, error) {
 	var r Reference
 	r.bucket = ss[0]
 	r.object = ss[1]
+
+	if u.Fragment != "" {
+		if generation, err := strconv.ParseInt(u.Fragment, 0, 64); err == nil {
+			r.generation = generation
+		}
+	}
 
 	// Parse out destination
 	switch d := u.Query().Get("destination"); d {

--- a/pkg/berglas/reference_test.go
+++ b/pkg/berglas/reference_test.go
@@ -86,6 +86,17 @@ func TestParseReference(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"destination_path",
+			"berglas://foo/bar?destination=/var/foo#12345678",
+			&Reference{
+				bucket:     "foo",
+				object:     "bar",
+				generation: 12345678,
+				filepath:   "/var/foo",
+			},
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/berglas/reference_test.go
+++ b/pkg/berglas/reference_test.go
@@ -88,11 +88,11 @@ func TestParseReference(t *testing.T) {
 		},
 		{
 			"destination_path",
-			"berglas://foo/bar?destination=/var/foo#12345678",
+			"berglas://foo/bar?destination=/var/foo#1563925173373377",
 			&Reference{
 				bucket:     "foo",
 				object:     "bar",
-				generation: 12345678,
+				generation: 1563925173373377,
 				filepath:   "/var/foo",
 			},
 			false,

--- a/pkg/berglas/resolver.go
+++ b/pkg/berglas/resolver.go
@@ -40,8 +40,9 @@ func (c *Client) Resolve(ctx context.Context, s string) ([]byte, error) {
 	}
 
 	plaintext, err := c.Access(ctx, &AccessRequest{
-		Bucket: ref.Bucket(),
-		Object: ref.Object(),
+		Bucket:     ref.Bucket(),
+		Object:     ref.Object(),
+		Generation: ref.Generation(),
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to access secret %s/%s", ref.Bucket(), ref.Object())


### PR DESCRIPTION
This lets us pin config version during deploys.