### PR TITLE
update berglas-cli docs for secret manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ stored in [Cloud Storage][cloud-storage]. An interoperable layer also exists wit
     Using Secret Manager storage:
 
     ```text
-    berglas create ${PROJECT_ID}/foo my-secret-data
+    berglas create sm://${PROJECT_ID}/foo my-secret-data
     ```
 
     Using Cloud Storage storage:
@@ -217,7 +217,7 @@ stored in [Cloud Storage][cloud-storage]. An interoperable layer also exists wit
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/foo --member user:user@mydomain.com
+    berglas grant sm://${PROJECT_ID}/foo --member user:user@mydomain.com
     ```
 
     Using Cloud Storage storage:
@@ -231,7 +231,7 @@ stored in [Cloud Storage][cloud-storage]. An interoperable layer also exists wit
     Using Secret Manager storage:
 
     ```text
-    berglas access ${PROJECT_ID}/foo
+    berglas access sm://${PROJECT_ID}/foo
     my-secret-data
     ```
 
@@ -255,7 +255,7 @@ stored in [Cloud Storage][cloud-storage]. An interoperable layer also exists wit
     Using Secret Manager storage:
 
     ```text
-    berglas access ${PROJECT_ID}/foo#1
+    berglas access sm://${PROJECT_ID}/foo#1
     my-previous-secret-data
     ```
 
@@ -271,7 +271,7 @@ stored in [Cloud Storage][cloud-storage]. An interoperable layer also exists wit
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/foo --member user:user@mydomain.com
+    berglas revoke sm://${PROJECT_ID}/foo --member user:user@mydomain.com
     my-previous-secret-data
     ```
 
@@ -286,7 +286,7 @@ stored in [Cloud Storage][cloud-storage]. An interoperable layer also exists wit
     Using Secret Manager storage:
 
     ```text
-    berglas delete ${PROJECT_ID}/foo
+    berglas delete sm://${PROJECT_ID}/foo
     ```
 
     Using Cloud Storage storage:

--- a/examples/appengine/go/README.md
+++ b/examples/appengine/go/README.md
@@ -37,11 +37,11 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
-    berglas create ${BUCKET_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
+    berglas create sm://${PROJECT_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
     ```
 
     Using Cloud Storage storage:
@@ -67,8 +67,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -116,8 +116,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/appengineflex/go/README.md
+++ b/examples/appengineflex/go/README.md
@@ -37,11 +37,11 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
-    berglas create ${BUCKET_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
+    berglas create sm://${PROJECT_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
     ```
 
     Using Cloud Storage storage:
@@ -68,8 +68,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -139,8 +139,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/appengineflex/node/README.md
+++ b/examples/appengineflex/node/README.md
@@ -37,11 +37,11 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
-    berglas create ${BUCKET_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
+    berglas create sm://${PROJECT_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
     ```
 
     Using Cloud Storage storage:
@@ -68,8 +68,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -133,8 +133,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/appengineflex/python/README.md
+++ b/examples/appengineflex/python/README.md
@@ -37,11 +37,11 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
-    berglas create ${BUCKET_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
+    berglas create sm://${PROJECT_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
     ```
 
     Using Cloud Storage storage:
@@ -68,8 +68,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -133,8 +133,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/appengineflex/ruby/README.md
+++ b/examples/appengineflex/ruby/README.md
@@ -38,11 +38,11 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
-    berglas create ${BUCKET_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
+    berglas create sm://${PROJECT_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
     ```
 
     Using Cloud Storage storage:
@@ -69,8 +69,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -134,8 +134,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/cloudbuild/README.md
+++ b/examples/cloudbuild/README.md
@@ -41,11 +41,11 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
-    berglas create ${BUCKET_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
+    berglas create sm://${PROJECT_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
     ```
 
     Using Cloud Storage storage:
@@ -72,8 +72,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -97,8 +97,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/cloudfunctions/go/README.md
+++ b/examples/cloudfunctions/go/README.md
@@ -31,11 +31,11 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
-    berglas create ${BUCKET_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
+    berglas create sm://${PROJECT_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
     ```
 
     Using Cloud Storage storage:
@@ -69,8 +69,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -116,8 +116,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/cloudrun/go/README.md
+++ b/examples/cloudrun/go/README.md
@@ -30,11 +30,11 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
-    berglas create ${BUCKET_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
+    berglas create sm://${PROJECT_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
     ```
 
     Using Cloud Storage storage:
@@ -65,8 +65,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -132,8 +132,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/cloudrun/node/README.md
+++ b/examples/cloudrun/node/README.md
@@ -30,11 +30,11 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
-    berglas create ${BUCKET_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
+    berglas create sm://${PROJECT_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
     ```
 
     Using Cloud Storage storage:
@@ -65,8 +65,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -132,8 +132,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/cloudrun/python/README.md
+++ b/examples/cloudrun/python/README.md
@@ -31,7 +31,7 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
@@ -66,8 +66,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -133,8 +133,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/cloudrun/ruby/README.md
+++ b/examples/cloudrun/ruby/README.md
@@ -31,11 +31,11 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas create ${BUCKET_ID}/api-key "xxx-yyy-zzz"
+    berglas create sm://${PROJECT_ID}/api-key "xxx-yyy-zzz"
     ```
 
     ```text
-    berglas create ${BUCKET_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
+    berglas create sm://${PROJECT_ID}/tls-key "=== BEGIN RSA PRIVATE KEY..."
     ```
 
     Using Cloud Storage storage:
@@ -66,8 +66,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas grant ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas grant sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Google Cloud storage:
@@ -133,8 +133,8 @@ instructions):
     Using Secret Manager storage:
 
     ```text
-    berglas revoke ${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
-    berglas revoke ${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/api-key --member serviceAccount:${SA_EMAIL}
+    berglas revoke sm://${PROJECT_ID}/tls-key --member serviceAccount:${SA_EMAIL}
     ```
 
     Using Cloud Storage storage:

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -94,7 +94,7 @@ cluster. For example:
     Using Secret Manager storage:
 
     ```text
-    berglas grant ${PROJECT_ID}/my-secret
+    berglas grant sm://${PROJECT_ID}/my-secret
     ```
 
     Using Cloud Storage storage:


### PR DESCRIPTION
Hello,

i just tried to create a secret using Berglas in google secret manager and had some problems during the way.

Steps to reproduce:

```zsh
brew install berglas # v0.5.2
export PROJECT_ID=my-gcp-project-id
gcloud services enable --project ${PROJECT_ID} secretmanager.googleapis.com

berglas create ${PROJECT_ID}/foo my-secret-data
# => missing key name
```


The problem was the missing prefix for secret manager.

```zsh
berglas create sm://${PROJECT_ID}/foo my-secret-data
#  => works
```

So i updated the docs 😉 