### PR TITLE
handle io.EOF allow for secrets from stdin without newline

### DIFF
--- a/main.go
+++ b/main.go
@@ -1273,7 +1273,14 @@ func readData(s string) ([]byte, error) {
 		return ioutil.ReadFile(s[1:])
 	case strings.HasPrefix(s, "-"):
 		r := bufio.NewReader(stdin)
-		return r.ReadBytes('\n')
+		b, err := r.ReadBytes('\n')
+		if err == io.EOF {
+			return b, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
 	case strings.HasPrefix(s, "\\"):
 		return []byte(s[1:]), nil
 	default:


### PR DESCRIPTION
```
echo -n 'foo' | berglas create $bucket/$secret - --key $key 
```
Resulted in `EOF` and exit code 161

Also version did not get bumped, its still on `0.5.0` see `pkg/berglas/berglas.go`
