### PR TITLE
read all data from stdin

### DIFF
--- a/main.go
+++ b/main.go
@@ -1273,7 +1273,7 @@ func readData(s string) ([]byte, error) {
 		return ioutil.ReadFile(s[1:])
 	case strings.HasPrefix(s, "-"):
 		r := bufio.NewReader(stdin)
-		b, err := r.ReadBytes('\n')
+		b, err := ioutil.ReadAll(r)
 		if err == io.EOF {
 			return b, nil
 		}


### PR DESCRIPTION
Follow up on https://github.com/GoogleCloudPlatform/berglas/pull/123:

It appears that reading from stdin was limited to 1 line only where `@foo` would read an entire file. 

This patch makes `berglas create $name @file ...` have the same outcome as `cat file | berglas create $name - ...`