### PR TITLE
Fix container name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ stored in [Cloud Storage][cloud-storage]. An interoperable layer also exists wit
       This will pull the latest version built against the master branch. To use
       a specific version, specify a git tag in place of "latest" in the URL.
 
-      Note: the `us-docker.pkg.dev/berglas/berglas/berglas` image remains for backwards
+      Note: the `gcr.io/berglas/berglas:latest` image remains for backwards
       compatability, but new versions are **not** published there.
 
     - Install from source (requires a working Go installation):


### PR DESCRIPTION
I think this line of the readme, introduced in commit https://github.com/GoogleCloudPlatform/berglas/commit/1b0a70c0093cf17d09f25a89316277fc3f564e1d contains a mistake?

Presumably the legacy Docker image is the gcr.io one, not the new pkg.dev one?

cc @sethvargo