### PR TITLE
Allow to read CA certs from user-specified location (fixes #144)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,6 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates && \
   update-ca-certificates
 
-COPY --from=builder /bin/berglas /bin/berglas
+RUN mkdir -p /opt/berglas/bin /opt/berglas/certs && ln -s /opt/berglas/bin/berglas /bin
+COPY --from=builder /bin/berglas /opt/berglas/bin/berglas
 ENTRYPOINT ["/bin/berglas"]


### PR DESCRIPTION
This PR is providing a solution for the scenario discussed in the issue #144. The user can build the following container to automatically load arbitrary CA from a directory specified via environment variable `BERGLAS_CA_DIR`:

```Dockerfile
FROM us-docker.pkg.dev/berglas/berglas/berglas:latest

RUN cp /usr/share/ca-certificates/mozilla/GlobalSign_Root_CA_-_R2.crt /opt/berglas/certs/
ENV BERGLAS_CA_DIR=/berglas/certs
```