### PR TITLE
Adding secrets handling

### DIFF
--- a/examples/kubernetes/main.go
+++ b/examples/kubernetes/main.go
@@ -2,11 +2,18 @@ package foo
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/GoogleCloudPlatform/berglas/pkg/berglas"
+	"github.com/pkg/errors"
 	kwhhttp "github.com/slok/kubewebhook/pkg/http"
 	kwhlog "github.com/slok/kubewebhook/pkg/log"
 	kwhmutating "github.com/slok/kubewebhook/pkg/webhook/mutating"
@@ -15,15 +22,137 @@ import (
 )
 
 const (
+	// showDebugMsgsAnnotKey is the name of a Pod Annotation key which
+	// indicates whether the debug mesages should be shown or not.
+	showDebugMsgsAnnotKey = "berglas-show-debug-messages"
+
+	// disabledAnnotKey is the name of a Pod Annotations key which
+	// explicitly disables Berglas for that Pod.
+	berglasEnabledAnnotKey = "berglas-enabled"
+
+	// containersSelectedAnnotKey is the name of a Pod Annotation key which
+	// specifies which init containers should only be selected for
+	// processing.
+	icontainersSelectedAnnotKey = "berglas-init-containers-selected"
+
+	// containersIgnoredAnnotKey is the name of a Pod Annotation key which
+	// specifies which init containers should be excluded from processing.
+	icontainersIgnoredAnnotKey = "berglas-init-containers-ignored"
+
+	// containersSelectedAnnotKey is the name of a Pod Annotation key which
+	// specifies which containers should only be selected for processing.
+	containersSelectedAnnotKey = "berglas-containers-selected"
+
+	// containersIgnoredAnnotKey is the name of a Pod Annotation key which
+	// specifies which containers should be excluded from processing.
+	containersIgnoredAnnotKey = "berglas-containers-ignored"
+
+	// queryRegistryAnnotKey is the name of a Pod Annotations key which
+	// indicates whether to try to get command from remote registry if not
+	// defined in the Pod.
+	queryRegistryAnnotKey = "berglas-query-registry"
+
+	// secretsEnabledAnnotKey is the name of a Pod Annotation key which
+	// indicates wherther the secrets should be processed or not.
+	secretsEnabledAnnotKey = "berglas-secrets-enabled"
+
+	// secretsIgnoreSaAnnotKey is the name of a Pod Annotation key which
+	// indicates whether the Service Account secrets should be ignored or
+	// not.
+	secretsIgnoreSaAnnotKey = "berglas-secrets-ignore-sa"
+
+	// volumesSelectedAnnotKey is the name of a Pod Annotation key which
+	// specifies which Volume names that reference secrets should only be
+	// selected for processing.
+	volumesSelectedAnnotKey = "berglas-secrets-volumes-selected"
+
+	// volumesIgnoredAnnotKey is the name of a Pod Annotation key which
+	// specifies which Volume names that reference secrets should be
+	// excluded from processing.
+	volumesIgnoredAnnotKey = "berglas-secrets-volumes-ignored"
+
+	// secretsExecUserAnnotKey is the name of a Pod Annotation key which
+	// specifies user and group under which Berglas should execute the
+	// container's command.
+	secretsExecUserAnnotKey = "berglas-secrets-exec-user"
+
+	// secretsRunAsUserAnnotKey is the name of a Pod Annotation key which
+	// specifies user ID that will be used for the runAsUser in the
+	// container securityContext.
+	secretsRunAsUserAnnotKey = "berglas-secrets-run-as-user"
+
+	// secretsRunAsGroupAnnotKey is the name of a Pod Annotation key which
+	// specifies user ID that will be used for the runAsGroup in the
+	// container securityContext.
+	secretsRunAsGroupAnnotKey = "berglas-secrets-run-as-group"
+
+	// secretsRunAsNonRootAnnotKey is the name of a Pod Annotation key
+	// which indicates whether to runAsNonRoot should be enabled or not in
+	// the container securityContext.
+	secretsRunAsNonRootAnnotKey = "berglas-secrets-run-as-non-root"
+
+	// secretsAllowPrivEscal is the name of a Pod Annotation key which
+	// indicates whether the secretsAllowPrivilegeEscalation should be
+	// enabled or not in the container securityContext.
+	secretsAllowPrivEscalAnnotKey = "berglas-secrets-allow-privilege-escalation"
+
+	// secretsRoRootFsEnabledAnnotKey is the name of a Pod Annotation key
+	// which indicates whether the readOnlyRootFilesystem should be enabled
+	// or not in the container securityContext.
+	secretsRoRootFsEnabledAnnotKey = "berglas-secrets-rorf-enabled"
+
 	// berglasContainer is the default berglas container from which to pull the
 	// berglas binary.
-	berglasContainer = "us-docker.pkg.dev/berglas/berglas/berglas:latest"
+	// TODO: berglasContainer = "us-docker.pkg.dev/berglas/berglas/berglas:latest"
+	berglasContainer = "jtyr/berglas:v1.5.0"
 
 	// binVolumeName is the name of the volume where the berglas binary is stored.
 	binVolumeName = "berglas-bin"
 
 	// binVolumeMountPath is the mount path where the berglas binary can be found.
 	binVolumeMountPath = "/berglas/bin/"
+
+	// saSecretPath is a path which Kubernetes uses to store Service Accout
+	// secrets inside the container.
+	saSecretPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+
+	// secretMountPathPostfix is a postfix added to every secret mountPath.
+	// TODO: secretMountPathPostfix = berglas.SecretsMountPathPostfix
+	secretMountPathPostfix = "..berglas"
+
+	// envSecretsPaths is the name of the env var which will hold list of
+	// files and directoris for Berglas to explore.
+	// TODO: envSecretsPaths = berglas.SecretsPathsEnvVarName
+	envSecretsPaths = "BERGLAS_SECRETS_PATHS"
+
+	// envExecUser is the name of the env var which will hold list of files
+	// and directoris for Berglas to explore.
+	// TODO: envExecUser = berglas.SecretsUserExecEnvVarName
+	envExecUser = "BERGLAS_SECRETS_EXEC_USER"
+)
+
+var (
+	// showDebugMsgs indicates whether to show debug messages by default.
+	showDebugMsgs = true
+
+	// berglasEnabled indicates whether the mutator should do anything by
+	// default.
+	berglasEnabled = true
+
+	// queryRegistry indicates whether to try to get command from remote
+	// registry by default if not defined in the Pod.
+	queryRegistry = true
+
+	// registryTimeout indicates how many seconds to wait before the request
+	// fails.
+	registryTimeout = 3
+
+	// secretsEnabled indicates whether to process secrets by default.
+	secretsEnabled = false
+
+	// secretsIgnoreSa indicates whether the Service Account secrets should
+	// be ignored by default.
+	secretsIgnoreSa = true
 )
 
 // binInitContainer is the container that pulls the berglas binary executable
@@ -59,42 +188,142 @@ var binVolumeMount = corev1.VolumeMount{
 	ReadOnly:  true,
 }
 
+// Config is a configuration for the mutator.
+type Config struct {
+	showDebugMsgs          bool
+	berglasEnabled         bool
+	icontainersSelected    []string
+	icontainersIgnored     []string
+	containersSelected     []string
+	containersIgnored      []string
+	queryRegistry          bool
+	secretsEnabled         bool
+	secretsIgnoreSa        bool
+	volumesSelected        []string
+	volumesIgnored         []string
+	secretsExecUser        string
+	secretsRunAsUser       *int64
+	secretsRunAsGroup      *int64
+	secretsRunAsNonRoot    *bool
+	secretsAllowPrivEscal  *bool
+	secretsRoRootFsEnabled *bool
+}
+
 // BerglasMutator is a mutator.
 type BerglasMutator struct {
 	logger kwhlog.Logger
+	config Config
+}
+
+// VolumesSecrets is used to store information about Volume secrets.
+type VolumesSecrets map[string][]string
+
+// DockerAuth is used for getting Docker registry access token.
+type DockerAuth struct {
+	Token string `json:"token"`
+}
+
+// DockerMeta is describing Docker registry metadata.
+type DockerMeta struct {
+	Config DockerMetaConfig `json:"config"`
+}
+
+// DockerMeta is describing configuration from the Docker registry metadata.
+type DockerMetaConfig struct {
+	Digest string `json:"digest"`
+}
+
+// DockerMeta is describing Docker registry blob.
+type DockerBlob struct {
+	Config DockerBlobConfig `json:"config"`
+}
+
+// DockerMeta is describing container config from the Docker registry blob.
+type DockerBlobConfig struct {
+	Entrypoint []string `json:"Entrypoint"`
+	Cmd        []string `json:"Cmd"`
+	User       string   `json:"User"`
 }
 
 // Mutate implements MutateFunc and provides the top-level entrypoint for object
 // mutation.
 func (m *BerglasMutator) Mutate(ctx context.Context, obj metav1.Object) (bool, error) {
-	m.logger.Infof("calling mutate")
-
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
+		m.logger.Errorf("not a pod")
 		return false, nil
+	}
+
+	// Check Pod Annotations if berlas should be disable.
+	annot := pod.ObjectMeta.GetAnnotations()
+
+	// Set config options.
+	m.setConfig(annot)
+
+	// Set logger.
+	m.logger = &kwhlog.Std{Debug: m.config.showDebugMsgs}
+
+	m.logger.Debugf("calling Mutate")
+
+	// Check if berglas is enabled.
+	if !m.config.berglasEnabled {
+		m.logger.Debugf("berglas explicity disabled")
+		return false, nil
+	}
+
+	// Check for Volumes with secret reference.
+	vs := make(VolumesSecrets)
+
+	for _, v := range pod.Spec.Volumes {
+		if v.VolumeSource.Secret != nil {
+			if valueInArray(m.config.volumesSelected, v.Name, true) &&
+				!valueInArray(m.config.volumesIgnored, v.Name, false) {
+
+				vs[v.Name] = nil
+
+				for _, i := range v.VolumeSource.Secret.Items {
+					vs[v.Name] = append(vs[v.Name], i.Path)
+				}
+			}
+		}
 	}
 
 	mutated := false
 
 	for i, c := range pod.Spec.InitContainers {
-		c, didMutate := m.mutateContainer(ctx, &c)
-		if didMutate {
-			mutated = true
-			pod.Spec.InitContainers[i] = *c
+		if valueInArray(m.config.icontainersSelected, c.Name, true) &&
+			!valueInArray(m.config.icontainersIgnored, c.Name, false) {
+
+			m.logger.Debugf("mutating init container: %s", c.Name)
+			c, didMutate := m.mutateContainer(ctx, &c, vs)
+			if didMutate {
+				mutated = true
+				pod.Spec.InitContainers[i] = *c
+			}
+		} else {
+			m.logger.Debugf("ignoring init container: %s", c.Name)
 		}
 	}
 
 	for i, c := range pod.Spec.Containers {
-		c, didMutate := m.mutateContainer(ctx, &c)
-		if didMutate {
-			mutated = true
-			pod.Spec.Containers[i] = *c
+		if valueInArray(m.config.containersSelected, c.Name, true) &&
+			!valueInArray(m.config.containersIgnored, c.Name, false) {
+
+			m.logger.Debugf("mutating container: %s", c.Name)
+			c, didMutate := m.mutateContainer(ctx, &c, vs)
+			if didMutate {
+				mutated = true
+				pod.Spec.Containers[i] = *c
+			}
+		} else {
+			m.logger.Debugf("ignoring container: %s", c.Name)
 		}
 	}
 
 	// If any of the containers requested berglas secrets, mount the shared volume
 	// and ensure the berglas binary is available via an init container.
 	if mutated {
+		m.logger.Debugf("adding berglas initContainer and volume")
 		pod.Spec.Volumes = append(pod.Spec.Volumes, binVolume)
 		pod.Spec.InitContainers = append([]corev1.Container{binInitContainer},
 			pod.Spec.InitContainers...)
@@ -105,17 +334,81 @@ func (m *BerglasMutator) Mutate(ctx context.Context, obj metav1.Object) (bool, e
 
 // mutateContainer mutates the given container, updating the volume mounts and
 // command if it contains berglas references.
-func (m *BerglasMutator) mutateContainer(_ context.Context, c *corev1.Container) (*corev1.Container, bool) {
-	// Ignore if there are no berglas references in the container.
-	if !m.hasBerglasReferences(c.Env) {
-		return c, false
+func (m *BerglasMutator) mutateContainer(_ context.Context, c *corev1.Container, vs VolumesSecrets) (*corev1.Container, bool) {
+	var metadata DockerBlobConfig
+	var command = c.Command
+
+	if m.config.queryRegistry {
+		meta, err := m.fetchMetaFromRegistry(c.Image)
+		if err != nil {
+			m.logger.Errorf("failed to fetch metadata from registry: %s", err)
+		}
+
+		metadata = meta
+
+		if m.config.secretsEnabled && metadata.User != "" {
+			m.logger.Debugf("setting user from the registry")
+			// Overwrite the exec user settings
+			m.config.secretsExecUser = metadata.User
+			// Force the container to run as root
+			intZero := int64(0)
+			falseBool := false
+			m.config.secretsRunAsUser = &intZero
+			m.config.secretsRunAsGroup = &intZero
+			m.config.secretsRunAsNonRoot = &falseBool
+		}
 	}
 
 	// Berglas prepends the command from the podspec. If there's no command in the
 	// podspec, there's nothing to append. Note: this is the command in the
-	// podspec, not a CMD or ENTRYPOINT in a Dockerfile.
-	if len(c.Command) == 0 {
-		m.logger.Warningf("cannot apply berglas to %s: container spec does not define a command", c.Name)
+	// podspec, not a CMD or ENTRYPOINT in a Dockerfile. We will try to get
+	// the command from the image metadata in the registry (see the
+	// queryRegistry config option).
+	if len(command) == 0 {
+		if metadata.Entrypoint != nil {
+			m.logger.Debugf("setting command to be the entrypoint from registry")
+			command = metadata.Entrypoint
+		} else if metadata.Cmd != nil {
+			m.logger.Debugf("setting command to be the cmd from registry")
+			command = metadata.Cmd
+		}
+
+		if command == nil {
+			m.logger.Warningf("cannot apply berglas to %s: container spec does not define a command", c.Name)
+			return c, false
+		}
+	}
+
+	var ms []string
+
+	// Compile list of paths to secrets.
+	if m.config.secretsEnabled {
+		for i, vm := range c.VolumeMounts {
+			if _, ok := vs[vm.Name]; ok {
+				if secretsIgnoreSa && vm.MountPath == saSecretPath {
+					m.logger.Debugf("ignoring SA secret: %s", vm.Name)
+				} else {
+					mountPath := filepath.Clean(vm.MountPath)
+					newMountPath := fmt.Sprintf("%s/%s", mountPath, secretMountPathPostfix)
+					m.logger.Debugf("mutating volumeMount[name=%s] to be %s", vm.Name, newMountPath)
+					c.VolumeMounts[i].MountPath = newMountPath
+
+					if len(vs[vm.Name]) > 0 {
+						for _, p := range vs[vm.Name] {
+							ms = append(ms, fmt.Sprintf("%s//%s", mountPath, filepath.Clean(p)))
+						}
+					} else {
+						ms = append(ms, vm.MountPath)
+					}
+				}
+			}
+		}
+	}
+
+	if !m.hasBerglasReferences(c.Env) && !m.hasEnvSecret(c.Env) && !m.hasEnvFromSecret(c.EnvFrom) && len(ms) == 0 {
+		// Ignore if there are no berglas references or no reference to
+		// a secret in the container.
+		m.logger.Debugf("no env or secret found")
 		return c, false
 	}
 
@@ -123,11 +416,86 @@ func (m *BerglasMutator) mutateContainer(_ context.Context, c *corev1.Container)
 	c.VolumeMounts = append(c.VolumeMounts, binVolumeMount)
 
 	// Prepend the command with berglas exec --
-	original := append(c.Command, c.Args...)
+	original := append(command, c.Args...)
 	c.Command = []string{binVolumeMountPath + "berglas"}
 	c.Args = append([]string{"exec", "--"}, original...)
 
+	if len(ms) > 0 {
+		evPaths := corev1.EnvVar{
+			Name:  envSecretsPaths,
+			Value: strings.Join(ms, ","),
+		}
+
+		m.logger.Debugf("adding env var: %s=%s", evPaths.Name, evPaths.Value)
+		c.Env = append(c.Env, evPaths)
+	}
+
+	// Add exec user
+	if m.config.secretsExecUser != "" {
+		evUser := corev1.EnvVar{
+			Name:  envExecUser,
+			Value: m.config.secretsExecUser,
+		}
+
+		m.logger.Debugf("adding env var: %s=%s", evUser.Name, evUser.Value)
+		c.Env = append(c.Env, evUser)
+	}
+
+	// Enforce security context
+	if c.SecurityContext == nil && (m.config.secretsRunAsUser != nil ||
+		m.config.secretsRunAsGroup != nil ||
+		m.config.secretsRunAsNonRoot != nil ||
+		m.config.secretsAllowPrivEscal != nil ||
+		m.config.secretsRoRootFsEnabled != nil) {
+
+		m.logger.Debugf("adding security context")
+		c.SecurityContext = &corev1.SecurityContext{}
+	}
+	if m.config.secretsRunAsUser != nil {
+		m.logger.Debugf("setting securityContext.runAsUser=%d", *m.config.secretsRunAsUser)
+		c.SecurityContext.RunAsUser = m.config.secretsRunAsUser
+	}
+	if m.config.secretsRunAsGroup != nil {
+		m.logger.Debugf("setting securityContext.runAsGroup=%d", *m.config.secretsRunAsGroup)
+		c.SecurityContext.RunAsGroup = m.config.secretsRunAsGroup
+	}
+	if m.config.secretsRunAsNonRoot != nil {
+		m.logger.Debugf("setting securityContext.runAsNonRoot=%t", *m.config.secretsRunAsNonRoot)
+		c.SecurityContext.RunAsNonRoot = m.config.secretsRunAsNonRoot
+	}
+	if m.config.secretsAllowPrivEscal != nil {
+		m.logger.Debugf("setting securityContext.allowPrivilegeEscalation=%t", *m.config.secretsAllowPrivEscal)
+		c.SecurityContext.AllowPrivilegeEscalation = m.config.secretsAllowPrivEscal
+	}
+	if m.config.secretsRoRootFsEnabled != nil {
+		m.logger.Debugf("setting securityContext.readOnlyRootFilesystem=%t", *m.config.secretsRoRootFsEnabled)
+		c.SecurityContext.ReadOnlyRootFilesystem = m.config.secretsRoRootFsEnabled
+	}
+
 	return c, true
+}
+
+// Set config options based on default values or values from Annotations.
+func (m *BerglasMutator) setConfig(annot map[string]string) {
+	// Global
+	m.config.showDebugMsgs = *getBoolAnnot(annot, showDebugMsgsAnnotKey, &showDebugMsgs)
+	m.config.berglasEnabled = *getBoolAnnot(annot, berglasEnabledAnnotKey, &berglasEnabled)
+	m.config.icontainersSelected = getStringArrayAnnot(annot, icontainersSelectedAnnotKey)
+	m.config.icontainersIgnored = getStringArrayAnnot(annot, icontainersIgnoredAnnotKey)
+	m.config.containersSelected = getStringArrayAnnot(annot, containersSelectedAnnotKey)
+	m.config.containersIgnored = getStringArrayAnnot(annot, containersIgnoredAnnotKey)
+	m.config.queryRegistry = *getBoolAnnot(annot, queryRegistryAnnotKey, &queryRegistry)
+	m.config.secretsEnabled = *getBoolAnnot(annot, secretsEnabledAnnotKey, &secretsEnabled)
+	// TODO: Per container (val@container1,val@container2)?
+	m.config.secretsIgnoreSa = *getBoolAnnot(annot, secretsIgnoreSaAnnotKey, &secretsIgnoreSa)
+	m.config.volumesSelected = getStringArrayAnnot(annot, volumesSelectedAnnotKey)
+	m.config.volumesIgnored = getStringArrayAnnot(annot, volumesIgnoredAnnotKey)
+	m.config.secretsExecUser = getStringAnnot(annot, secretsExecUserAnnotKey)
+	m.config.secretsRunAsUser = getInt64Annot(annot, secretsRunAsUserAnnotKey, nil)
+	m.config.secretsRunAsGroup = getInt64Annot(annot, secretsRunAsGroupAnnotKey, nil)
+	m.config.secretsRunAsNonRoot = getBoolAnnot(annot, secretsRunAsNonRootAnnotKey, nil)
+	m.config.secretsAllowPrivEscal = getBoolAnnot(annot, secretsAllowPrivEscalAnnotKey, nil)
+	m.config.secretsRoRootFsEnabled = getBoolAnnot(annot, secretsRoRootFsEnabledAnnotKey, nil)
 }
 
 // hasBerglasReferences parses the environment and returns true if any of the
@@ -135,15 +503,252 @@ func (m *BerglasMutator) mutateContainer(_ context.Context, c *corev1.Container)
 func (m *BerglasMutator) hasBerglasReferences(env []corev1.EnvVar) bool {
 	for _, e := range env {
 		if berglas.IsReference(e.Value) {
+			m.logger.Debugf("found berglas reference in env")
 			return true
 		}
 	}
+
+	return false
+}
+
+// hasEnvSecret parses the environment and returns true if any of the
+// environment variables is a reference to a secret.
+func (m *BerglasMutator) hasEnvSecret(env []corev1.EnvVar) bool {
+	if !m.config.secretsEnabled {
+		return false
+	}
+
+	for _, e := range env {
+		if e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+			m.logger.Debugf("found env secret")
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasEnvFromSecret parses the environment from and returns true if any of the
+// environment variables is a reference to a secret.
+func (m *BerglasMutator) hasEnvFromSecret(env []corev1.EnvFromSource) bool {
+	if !m.config.secretsEnabled {
+		return false
+	}
+
+	for _, e := range env {
+		if e.SecretRef != nil {
+			m.logger.Debugf("found envFrom secret")
+			return true
+		}
+	}
+
+	return false
+}
+
+// Fetch image metadata from remote registry.
+func (m *BerglasMutator) fetchMetaFromRegistry(img string) (DockerBlobConfig, error) {
+	var data DockerBlobConfig
+
+	// Normalize the image name
+	if strings.Index(img, "/") == -1 {
+		img = fmt.Sprintf("library/%s", img)
+	}
+
+	parts := strings.Split(img, "/")
+
+	var isDockerHub bool
+	if len(parts) == 1 || len(parts) == 2 {
+		isDockerHub = true
+	}
+
+	var registry string
+	var imgPath string
+	var imgTag string
+
+	// Determine or set image tag
+	lastPart := len(parts) - 1
+	imgTagParts := strings.Split(parts[lastPart], ":")
+	if len(imgTagParts) == 1 {
+		imgTag = "latest"
+	} else {
+		parts[lastPart] = imgTagParts[0]
+		imgTag = imgTagParts[1]
+	}
+
+	// Set registry and image path
+	if isDockerHub {
+		registry = "registry-1.docker.io"
+		imgPath = strings.Join(parts, "/")
+	} else {
+		registry = parts[0]
+		imgPath = strings.Join(parts[1:], "/")
+	}
+
+	// Get token
+	header := make(http.Header)
+	if isDockerHub {
+		tokenBody, err := m.fetchJson(fmt.Sprintf("https://auth.docker.io/token?service=registry.docker.io&scope=repository:%s:pull", imgPath), nil)
+		if err != nil {
+			return data, errors.Wrapf(err, "failed to fetch token data")
+		}
+
+		var tokenData DockerAuth
+		if err := json.Unmarshal(tokenBody, &tokenData); err != nil {
+			return data, errors.Wrapf(err, "failed to parse token JSON data")
+		}
+
+		if tokenData.Token != "" {
+			header.Set("Authorization", fmt.Sprintf("Bearer %s", tokenData.Token))
+		} else {
+			return data, errors.Wrapf(err, "invalid token data received: %s", tokenBody)
+		}
+	}
+
+	// Request image digest
+	header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	digestBody, err := m.fetchJson(fmt.Sprintf("https://%s/v2/%s/manifests/%s", registry, imgPath, imgTag), header)
+	if err != nil {
+		return data, errors.Wrapf(err, "failed to fetch digest data")
+	}
+
+	var digestData DockerMeta
+	if err := json.Unmarshal(digestBody, &digestData); err != nil {
+		return data, errors.Wrapf(err, "failed to parse digest JSON data")
+	}
+
+	// Request final metadata
+	if digestData.Config.Digest == "" {
+		return data, errors.Wrapf(err, "invalid digest data received: %s", digestBody)
+	} else {
+		blobBody, err := m.fetchJson(fmt.Sprintf("https://%s/v2/%s/blobs/%s", registry, imgPath, digestData.Config.Digest), header)
+		if err != nil {
+			return data, errors.Wrapf(err, "failed to fetch blob data")
+		}
+
+		var blobData DockerBlob
+		if err := json.Unmarshal(blobBody, &blobData); err != nil {
+			return data, errors.Wrapf(err, "failed to parse blob JSON data")
+		}
+
+		if blobData.Config.Entrypoint == nil && blobData.Config.Cmd == nil {
+			return data, errors.Wrapf(err, "invalid blob data received: %s", blobBody)
+		} else {
+			data = blobData.Config
+		}
+	}
+
+	return data, nil
+}
+
+// Fetch JSON from remote API.
+func (m *BerglasMutator) fetchJson(url string, header http.Header) ([]byte, error) {
+	var data []byte
+
+	client := http.Client{
+		Timeout: time.Second * time.Duration(registryTimeout),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return data, errors.Wrapf(err, "failed to build request")
+	}
+
+	if header != nil {
+		req.Header = header
+	}
+
+	resp, getErr := client.Do(req)
+	if getErr != nil {
+		return data, errors.Wrapf(getErr, "failed to execute request")
+	}
+
+	if resp.StatusCode != 200 {
+		return data, errors.Wrapf(errors.New(resp.Status), "incorrect status code returned")
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	body, readErr := ioutil.ReadAll(resp.Body)
+	if readErr != nil {
+		return data, errors.Wrapf(readErr, "failed to read response body")
+	}
+
+	data = body
+
+	return data, nil
+}
+
+// Return the annotation's or the default bool value.
+func getBoolAnnot(annot map[string]string, key string, defVal *bool) *bool {
+	if val, ok := annot[key]; ok {
+		bVal := false
+
+		if val == "yes" || val == "true" {
+			bVal = true
+		}
+
+		return &bVal
+	}
+
+	return defVal
+}
+
+// Return the annotation's or the default int64 value.
+func getInt64Annot(annot map[string]string, key string, defVal *int64) *int64 {
+	if val, ok := annot[key]; ok {
+		if n, err := strconv.Atoi(val); err == nil {
+			iVal := int64(n)
+			return &iVal
+		}
+	}
+
+	return defVal
+}
+
+// Return the annotation's value splitted into array of strings.
+func getStringArrayAnnot(annot map[string]string, key string) []string {
+	if val, ok := annot[key]; ok {
+		var vals []string
+
+		for _, v := range strings.Split(val, ",") {
+			vals = append(vals, strings.TrimSpace(v))
+		}
+
+		return vals
+	}
+
+	return []string{}
+}
+
+// Return the annotation's value.
+func getStringAnnot(annot map[string]string, key string) string {
+	if val, ok := annot[key]; ok {
+		return val
+	}
+
+	return ""
+}
+
+// Return true if the string is in the array.
+func valueInArray(a []string, s string, d bool) bool {
+	if len(a) == 0 {
+		return d
+	}
+
+	for _, v := range a {
+		if v == s {
+			return true
+		}
+	}
+
 	return false
 }
 
 // webhookHandler is the http.Handler that responds to webhooks
 func webhookHandler() http.Handler {
-	logger := &kwhlog.Std{Debug: true}
+	logger := &kwhlog.Std{Debug: showDebugMsgs}
 
 	mutator := &BerglasMutator{logger: logger}
 
@@ -165,6 +770,7 @@ func webhookHandler() http.Handler {
 		logger.Errorf("error creating webhook handler: %s", err)
 		os.Exit(1)
 	}
+
 	return whhandler
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	cloud.google.com/go v0.60.0
 	cloud.google.com/go/storage v1.10.0
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/gammazero/workerpool v0.0.0-20200608033439-1a5ca90a5753
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/protobuf v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gammazero/deque v0.0.0-20200227231300-1e9af0e52b46 h1:iX4+rD9Fjdx8SkmSO/O5WAIX/j79ll3kuqv5VdYt9J8=
 github.com/gammazero/deque v0.0.0-20200227231300-1e9af0e52b46/go.mod h1:D90+MBHVc9Sk1lJAbEVgws0eYEurY4mv2TDso3Nxh3w=

--- a/pkg/berglas/copy_secrets.go
+++ b/pkg/berglas/copy_secrets.go
@@ -1,0 +1,346 @@
+// Copyright 2019 The Berglas Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package berglas
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/pkg/errors"
+)
+
+const (
+	// SecretsMountPathPostfix is a postfix added to every secret mountPath.
+	SecretsMountPathPostfix = "..berglas"
+
+	// SecretsPathsEnvVarName is the name of the env var which can hold
+	// list of files and directoris for Berglas to explore.
+	SecretsPathsEnvVarName = "BERGLAS_SECRETS_PATHS"
+
+	// SecretsExecUserEnvVarName is the name of the env var which can hold
+	// user and group definition used by Berglas to execute the command as.
+	SecretsExecUserEnvVarName = "BERGLAS_SECRETS_EXEC_USER"
+)
+
+var (
+	stderr = os.Stderr
+)
+
+func (c *Client) CopySecrets(ctx context.Context, envVarContent string) error {
+	if len(envVarContent) == 0 {
+		return nil
+	}
+
+	dirsToWatch := make(map[string][]string)
+
+	for _, p := range strings.Split(envVarContent, ",") {
+		elems := strings.Split(p, "//")
+
+		if len(elems) == 1 {
+			if err := c.processDirectory(elems[0], ctx); err != nil {
+				return errors.Wrapf(err, "failed to process directory %s", elems[0])
+			}
+
+			dirsToWatch[elems[0]] = nil
+		} else if len(elems) == 2 {
+			if err := c.processFile(elems[0], elems[1], ctx); err != nil {
+				return errors.Wrapf(err, "failed to process file %s/%s", elems[0], elems[1])
+			}
+
+			dirsToWatch[elems[0]] = append(dirsToWatch[elems[0]], elems[1])
+		}
+	}
+
+	for dir, files := range dirsToWatch {
+		go c.addWatcher(dir, files, ctx)
+	}
+
+	return nil
+}
+
+func (c *Client) processDirectory(destDir string, ctx context.Context) error {
+	srcDir := fmt.Sprintf("%s/%s", destDir, SecretsMountPathPostfix)
+
+	files, err := ioutil.ReadDir(srcDir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read directory %s", srcDir)
+	}
+
+	for _, f := range files {
+		if f.Mode()&os.ModeSymlink == os.ModeSymlink && !strings.HasPrefix(f.Name(), "..") {
+			srcFilePath := fmt.Sprintf("%s/%s", srcDir, f.Name())
+			fullDestFilePath := fmt.Sprintf("%s/%s", destDir, f.Name())
+
+			isSecSym, err := c.isSecretSymlink(srcFilePath)
+			if err != nil {
+				return errors.Wrapf(err, "failed to check if file is secret symlink")
+			}
+
+			if isSecSym {
+				if err := c.treatFile(srcFilePath, fullDestFilePath, ctx); err != nil {
+					return errors.Wrapf(err, "failed to treat directory file")
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) processFile(destDir, filePath string, ctx context.Context) error {
+	srcFilePath := fmt.Sprintf("%s/%s/%s", destDir, SecretsMountPathPostfix, filePath)
+	fullDestFilePath := fmt.Sprintf("%s/%s", destDir, filePath)
+
+	pathDirs := strings.Split(filePath, "/")
+
+	firstSrcDirPath := fmt.Sprintf("%s/%s/%s", destDir, SecretsMountPathPostfix, pathDirs[0])
+
+	isSecSym, err := c.isSecretSymlink(firstSrcDirPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if first src dir is secret symlink")
+	}
+
+	if isSecSym {
+		if err := c.treatFile(srcFilePath, fullDestFilePath, ctx); err != nil {
+			return errors.Wrapf(err, "failed to treat file")
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) isSecretSymlink(file string) (bool, error) {
+	s, err := os.Readlink(file)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to read symlink %s", file)
+	}
+
+	if strings.HasPrefix(s, "..data") {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *Client) treatFile(src, dest string, ctx context.Context) error {
+	isRef, ref, err := c.isContentReference(src)
+	if err != nil {
+		return errors.Wrapf(err, "failed to verify reference")
+	}
+
+	if isRef {
+		content, err := c.Resolve(ctx, ref)
+		if err != nil {
+			return errors.Wrapf(err, "failed to resolve reference")
+		}
+
+		if err := c.createFile(src, dest, string(content)); err != nil {
+			return errors.Wrapf(err, "failed to create file")
+		}
+	} else {
+		if err := c.copyFile(src, dest); err != nil {
+			return errors.Wrapf(err, "failed to copy file")
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) isContentReference(file string) (bool, string, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return false, "", errors.Wrapf(err, "failed to open file %s", file)
+	}
+	defer f.Close()
+
+	line := ""
+	scanner := bufio.NewScanner(f)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		line = scanner.Text()
+		break
+	}
+
+	if IsSecretManagerReference(line) {
+		return true, line, nil
+	}
+
+	return false, "", nil
+}
+
+func (c *Client) createFile(src, dest, content string) error {
+	os.MkdirAll(path.Dir(dest), 0755)
+
+	mode, err := c.getMode(src)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get mode")
+	}
+
+	err = ioutil.WriteFile(dest, []byte(content), mode)
+	if err != nil {
+		return errors.Wrapf(err, "failed to write file")
+	}
+
+	return nil
+}
+
+func (c *Client) copyFile(src, dest string) error {
+	os.MkdirAll(path.Dir(dest), 0755)
+
+	from, err := os.Open(src)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open src file %s", src)
+	}
+	defer from.Close()
+
+	mode, err := c.getMode(src)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get mode")
+	}
+
+	to, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open dest file %s", dest)
+	}
+	defer to.Close()
+
+	_, err = io.Copy(to, from)
+	if err != nil {
+		return errors.Wrapf(err, "failed to copy file %s to %s", from, to)
+	}
+
+	return nil
+}
+
+func (c *Client) getMode(p string) (os.FileMode, error) {
+	from, err := os.Open(p)
+	if err != nil {
+		return os.FileMode(int(0)), errors.Wrapf(err, "failed to open file %s", p)
+	}
+	defer from.Close()
+
+	stat, err := from.Stat()
+	if err != nil {
+		return os.FileMode(int(0)), errors.Wrapf(err, "failed to stat file %s", p)
+	}
+
+	return stat.Mode(), nil
+}
+
+func (c *Client) addWatcher(dir string, files []string, ctx context.Context) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to create new watcher for %s: %s\n", dir, err)
+	}
+	defer watcher.Close()
+
+	done := make(chan bool)
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					fmt.Fprintf(stderr, "failed to get watcher events for %s\n", dir)
+					return
+				}
+
+				if event.Op&fsnotify.Create == fsnotify.Create && strings.HasSuffix(event.Name, "..data") {
+					if len(files) == 0 {
+						if err := c.processDirectory(dir, ctx); err != nil {
+							fmt.Fprintf(stderr, "failed to process directory %s from the watcher: %s\n", dir, err)
+							return
+						}
+					} else {
+						for _, f := range files {
+							if err := c.processFile(dir, f, ctx); err != nil {
+								fmt.Fprintf(stderr, "failed to process file %s/%s from the watcher: %s\n", dir, f, err)
+								return
+							}
+						}
+					}
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					fmt.Fprintf(stderr, "failed to get watcher errors for %s: %s\n", dir, err)
+					return
+				}
+			}
+		}
+	}()
+
+	err = watcher.Add(fmt.Sprintf("%s/%s", dir, SecretsMountPathPostfix))
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to add watcher for %s: %s\n", dir, err)
+		return
+	}
+
+	<-done
+}
+
+func GetUidGid(input string) (uint32, uint32, error) {
+	parts := strings.Split(input, ":")
+
+	var usr *user.User
+	// As per Docker documentation, the default group is root
+	grp := user.Group{
+		Gid: "0",
+	}
+
+	userByName, err := user.LookupId(parts[0])
+	if err != nil {
+		userById, err := user.Lookup(parts[0])
+		if err != nil {
+			return 0, 0, errors.Wrapf(err, "failed to lookup user")
+		}
+		usr = userById
+	} else {
+		usr = userByName
+	}
+
+	uid, err := strconv.Atoi(usr.Uid)
+	if err != nil {
+		return 0, 0, errors.Wrapf(err, "failed to convert uid to int")
+	}
+
+	if len(parts) == 2 {
+		groupByName, err := user.LookupGroupId(parts[1])
+		if err != nil {
+			groupById, err := user.LookupGroup(parts[1])
+			if err != nil {
+				return 0, 0, errors.Wrapf(err, "failed to lookup group")
+			}
+			grp = *groupById
+		} else {
+			grp = *groupByName
+		}
+	}
+
+	gid, err := strconv.Atoi(grp.Gid)
+	if err != nil {
+		return 0, 0, errors.Wrapf(err, "failed to convert gid to int")
+	}
+
+	return uint32(uid), uint32(gid), nil
+}


### PR DESCRIPTION
This PR extends Berglas by adding support for these features:

- Recognize secrets defined in `envFrom` (fixes issue #62).
- Recognize secrets mounted as files from Kubernetes secrets.
- Recognize secrets in the Pod `command` (fixes issue #143).
- Get `command` from the `ENTRYPOINT` or `CMD` defined in Docker image in the remote Registry if it's missing in the Pod definition.
- Configuration via Pod Annotations.

In order to support Kubernetes secrets as the source of reference for Berglas, several workarounds had to be implemented:

1) Kubernetes secretes are mounted as R/O. So even if we can read the content of the file, we cannot replace the Berglas reference with the real value in the file. This is why the webhook mutates mountPath of the secrets to be `<original_path>/..berglas`. Then when `berglas` starts on the final container, it will walk through those paths and copy the secrets into their original location (`<original_path>/`). File watcher it set up for each directory to reflect any changes to the mounted secret by Kubernetes.

2) In order to be able to do what's described in 1), Berglas needs to have write permission for that. This is why the webhook mutates the `securityContext` and runs the container always as `root` (or by selected user via Pod Annotations) if other `USER`/`GROUP` is defined. In order to respect the `USER`/`GROUP` under which the final application is suppose to run, the `USER`/`GROUP` is either fetched from the Docker metadata available in the remote Registry _OR_ the user can define a Pod Annotation when such information can be specified.

I realize that this is rather complex change. Please let me know if you want me to go into more details.