### PR TITLE
add Secret Manager example

### DIFF
--- a/examples/appengine/go/README.md
+++ b/examples/appengine/go/README.md
@@ -80,6 +80,19 @@ instructions):
 
 1. Create environment:
 
+    Using Secret Manager storage:
+    
+    ```text
+    cat > env.yaml <<EOF
+    env_variables:
+      GO111MODULE: on
+      API_KEY: sm://${PROJECT_ID}/api-key 
+      TLS_KEY: sm://${PROJECT_ID}/tls-key?destination=tempfile
+    EOF
+    ```
+
+    Using Google Cloud storage:
+    
     ```text
     cat > env.yaml <<EOF
     env_variables:


### PR DESCRIPTION
I added it because the secret manager pattern is missing.

Other examples are missing the case of Secret Manager as well, but I have only confirmed the operation of App Engine Standard.