### PR TITLE
Implemented option for custom SM locations

### DIFF
--- a/main.go
+++ b/main.go
@@ -651,6 +651,12 @@ func createRun(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(stdout, "Successfully created secret [%s] with version [%s]\n",
 			secret.Name, secret.Version)
 	case berglas.ReferenceTypeStorage:
+		// Check if no unsupported options have been given
+		if len(smLocations) > 0 {
+			return misuseError(fmt.Errorf("locations on a per-secret basis unsupported for Storage keys"))
+		}
+
+		// Create the requested secret
 		secret, err := client.Create(ctx, &berglas.StorageCreateRequest{
 			Bucket:    ref.Bucket(),
 			Object:    ref.Object(),
@@ -660,6 +666,7 @@ func createRun(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return apiError(err)
 		}
+
 		fmt.Fprintf(stdout, "Successfully created secret [%s] with generation [%d]\n",
 			secret.Name, secret.Generation)
 	default:

--- a/main.go
+++ b/main.go
@@ -451,7 +451,7 @@ func main() {
 	createCmd.Flags().StringVar(&key, "key", "",
 		"KMS key to use for encryption")
 	createCmd.Flags().StringSliceVar(&smLocations, "locations", nil,
-		"Canonical IDs (e.g. 'us-east1') to replicate secrets to, seperated by comma's")
+		"Comma-separated canonical IDs in which to replicate secrets (e.g. 'us-east1,us-west-1')")
 
 	rootCmd.AddCommand(deleteCmd)
 

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ var (
 	kmsLocation    string
 	kmsKeyRing     string
 	kmsCryptoKey   string
+	smLocations    []string
 )
 
 var rootCmd = &cobra.Command{
@@ -449,6 +450,8 @@ func main() {
 	rootCmd.AddCommand(createCmd)
 	createCmd.Flags().StringVar(&key, "key", "",
 		"KMS key to use for encryption")
+	createCmd.Flags().StringSliceVar(&smLocations, "locations", nil,
+		"Canonical IDs (e.g. 'us-east1') to replicate secrets to, seperated by comma's")
 
 	rootCmd.AddCommand(deleteCmd)
 
@@ -639,6 +642,7 @@ func createRun(cmd *cobra.Command, args []string) error {
 		secret, err := client.Create(ctx, &berglas.SecretManagerCreateRequest{
 			Project:   ref.Project(),
 			Name:      ref.Name(),
+			Locations: smLocations,
 			Plaintext: plaintext,
 		})
 		if err != nil {

--- a/pkg/berglas/berglas.go
+++ b/pkg/berglas/berglas.go
@@ -140,6 +140,11 @@ type Secret struct {
 
 	// KMSKey is the key used to encrypt the secret key. Cloud Storage only.
 	KMSKey string
+
+	// Locations is the list of custom locations a Secret Manager secret has
+	// been replicated to. Just set to nil if the secret is automatically
+	// replicated.
+	Locations []string
 }
 
 // secretFromAttrs constructs a secret from the given object attributes and

--- a/pkg/berglas/berglas.go
+++ b/pkg/berglas/berglas.go
@@ -141,9 +141,9 @@ type Secret struct {
 	// KMSKey is the key used to encrypt the secret key. Cloud Storage only.
 	KMSKey string
 
-	// Locations is the list of custom locations a Secret Manager secret has
-	// been replicated to. Just set to nil if the secret is automatically
-	// replicated.
+	// Locations is the list of custom locations the secret is replicated to.
+	// This is set to nil if the secret is automatically replicated instead.
+	// Secret Manager only.
 	Locations []string
 }
 

--- a/pkg/berglas/create_test.go
+++ b/pkg/berglas/create_test.go
@@ -48,7 +48,7 @@ func TestClient_Create_secretManager(t *testing.T) {
 		}
 
 		if createResp.Locations != nil {
-			t.Errorf("expected the locations to be set to `nil`, got %+v", createResp.Locations)
+			t.Errorf("expected %#v to be %#v", createResp.Locations, nil)
 		}
 		if !reflect.DeepEqual(createResp, readResp) {
 			t.Errorf("expected %#v to be %#v", createResp, readResp)

--- a/pkg/berglas/create_test.go
+++ b/pkg/berglas/create_test.go
@@ -47,6 +47,43 @@ func TestClient_Create_secretManager(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		if createResp.Locations != nil {
+			t.Errorf("expected the locations to be set to `nil`, got %+v", createResp.Locations)
+		}
+		if !reflect.DeepEqual(createResp, readResp) {
+			t.Errorf("expected %#v to be %#v", createResp, readResp)
+		}
+	})
+
+	t.Run("custom-locations", func(t *testing.T) {
+		t.Parallel()
+
+		client, ctx := testClient(t)
+		project, name := testProject(t), testName(t)
+		plaintext := []byte("my secret value")
+
+		createResp, err := client.Create(ctx, &SecretManagerCreateRequest{
+			Project:   project,
+			Name:      name,
+			Plaintext: plaintext,
+			Locations: []string{"europe-west1", "europe-west4"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer testSecretManagerCleanup(t, project, name)
+
+		readResp, err := client.Read(ctx, &SecretManagerReadRequest{
+			Project: project,
+			Name:    name,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(createResp.Locations, []string{"europe-west1", "europe-west4"}) {
+			t.Errorf("expected the locations to be set to `nil`, got %+v", createResp.Locations)
+		}
 		if !reflect.DeepEqual(createResp, readResp) {
 			t.Errorf("expected %#v to be %#v", createResp, readResp)
 		}

--- a/pkg/berglas/read.go
+++ b/pkg/berglas/read.go
@@ -144,12 +144,24 @@ func (c *Client) secretManagerRead(ctx context.Context, i *SecretManagerReadRequ
 		return nil, errors.Wrap(err, "failed to access secret")
 	}
 
+	logger.Debug("parsing location")
+
+	var locations []string
+	replication := versionResp.ReplicationStatus.GetUserManaged()
+	if replication != nil {
+		locations = make([]string, len(replication.Replicas))
+		for i, r := range replication.Replicas {
+			locations[i] = r.Location
+		}
+	}
+
 	return &Secret{
 		Parent:    project,
 		Name:      name,
 		Version:   path.Base(versionResp.Name),
 		Plaintext: accessResp.Payload.Data,
 		UpdatedAt: timestampToTime(versionResp.CreateTime),
+		Locations: locations,
 	}, nil
 }
 

--- a/pkg/berglas/read.go
+++ b/pkg/berglas/read.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	"sort"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -154,6 +155,7 @@ func (c *Client) secretManagerRead(ctx context.Context, i *SecretManagerReadRequ
 			locations[i] = r.Location
 		}
 	}
+	sort.Strings(locations)
 
 	return &Secret{
 		Parent:    project,


### PR DESCRIPTION
This PR contains backwards-compatible code which allows users to specify which locations they want a newly-created secret replicated to. It also passes this information along when reading a secret. The newly-created Locations parameter is set to (or kept at) `nil` when automatic replication is chosen instead.

This change is necessary for organisations where the rules only allow limited replication. Or where the secrets might contain PII and the GDPR places limits on the areas to store them at. The syntax is kept simple (and optional) without any complex options to keep Berglas as an easy-to-use wrapper.