### PR TITLE
Restore binary path inside the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ FROM --platform=$BUILDPLATFORM alpine AS builder
 RUN apk --no-cache add ca-certificates && \
   update-ca-certificates
 
-COPY berglas /berglas
-ENTRYPOINT ["/berglas"]
+COPY berglas /bin/berglas
+ENTRYPOINT ["/bin/berglas"]


### PR DESCRIPTION
This should be /bin/berglas, but was mistakenly changed to /berglas.