### PR TITLE
Update `berglas access` to output with newline

### DIFF
--- a/main.go
+++ b/main.go
@@ -536,7 +536,7 @@ func accessRun(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return apiError(err)
 		}
-		fmt.Fprintf(stdout, "%s", plaintext)
+		fmt.Fprintf(stdout, "%s\n", plaintext)
 	case berglas.ReferenceTypeStorage:
 		plaintext, err := client.Access(ctx, &berglas.StorageAccessRequest{
 			Bucket:     ref.Bucket(),
@@ -546,7 +546,7 @@ func accessRun(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return apiError(err)
 		}
-		fmt.Fprintf(stdout, "%s", plaintext)
+		fmt.Fprintf(stdout, "%s\n", plaintext)
 	default:
 		return misuseError(fmt.Errorf("unknown type %T", t))
 	}


### PR DESCRIPTION
# problem
Currently, `berglas access` does not output with a newline, whereas other commands such as `berglas list` does.

# solution

This PR  aligns the behavior and makes the output of `berglas access` more user-friendly and consistnent with the standard conventions of CLI commands.

# use case

I wanted to output the contents of all secrets.

` berglas list sm://${PROJECT_ID} |grep -v NAME | awk '{print $1}' | sort -n | xargs -I {} berglas access sm://${PROJECT_ID}/{}`
