### PR TITLE
Add support for rich JSON secrets

### DIFF
--- a/doc/reference-syntax.md
+++ b/doc/reference-syntax.md
@@ -46,6 +46,11 @@ sm://[PROJECT]/[NAME]?[OPTIONS]#[VERSION]
     - `[PATH]` - resolve the secret and write the contents to the specified file
       path.
 
+- `path` - when this URL query parameter is supplied, the value of the
+  secret must be a JSON object. Berglas will deserialize and then
+  treat `path` as a [JMESPath](https://jmespath.org/) query to extract
+  a single value from the object.
+
 ## Examples
 
 Read a Cloud Storage secret:
@@ -70,4 +75,10 @@ Read a specific generation of a secret:
 
 ```text
 sm://my-project/my-secret#13
+```
+
+Read a path from a secret that is encoded as a JSON object:
+
+```text
+sm://my-project/my-secret?path=password
 ```

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.10.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,9 @@ github.com/googleapis/gax-go/v2 v2.10.0/go.mod h1:4UOEnMCrxsSqQ940WnTiD6qJ63le2e
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -219,6 +222,7 @@ google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/berglas/reference.go
+++ b/pkg/berglas/reference.go
@@ -49,9 +49,10 @@ type Reference struct {
 	generation int64
 
 	// Secret Manager properties
-	project string
-	name    string
-	version string
+	project  string
+	name     string
+	version  string
+	jmespath string
 
 	// Common properties
 	typ      ReferenceType
@@ -92,9 +93,15 @@ func (r *Reference) Version() string {
 	return r.version
 }
 
-// Filepath is the disk to write the reference, if any.
+// Filepath is the file to write the reference, if any.
 func (r *Reference) Filepath() string {
 	return r.filepath
+}
+
+// JMESPath is a JMESPath expression used to extract a single item
+// from a secret stored as a JSON-encoded object.
+func (r *Reference) JMESPath() string {
+	return r.jmespath
 }
 
 // Type is the type of reference, used for switching.
@@ -190,6 +197,9 @@ func secretManagerParseReference(s string) (*Reference, error) {
 		return nil, err
 	}
 	r.filepath = path
+
+	// Parse JMESPath
+	r.jmespath = u.Query().Get("path")
 
 	return &r, nil
 }

--- a/pkg/berglas/reference_test.go
+++ b/pkg/berglas/reference_test.go
@@ -99,6 +99,42 @@ func TestParseReference(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"jmespath",
+			"sm://foo/bar?path=quux",
+			&Reference{
+				project:  "foo",
+				name:     "bar",
+				jmespath: "quux",
+				typ:      ReferenceTypeSecretManager,
+			},
+			false,
+		},
+		{
+			"jmespath",
+			"sm://foo/bar?path=quux#12",
+			&Reference{
+				project:  "foo",
+				name:     "bar",
+				jmespath: "quux",
+				version:  "12",
+				typ:      ReferenceTypeSecretManager,
+			},
+			false,
+		},
+		{
+			"jmespath-and-destination_path",
+			"sm://foo/bar?path=quux&destination=/var/foo#12",
+			&Reference{
+				project:  "foo",
+				name:     "bar",
+				jmespath: "quux",
+				version:  "12",
+				filepath: "/var/foo",
+				typ:      ReferenceTypeSecretManager,
+			},
+			false,
+		},
 
 		// Storage
 		{


### PR DESCRIPTION
This permits a user to store JSON objects as GSM data, and query specific items in those objects with a JMESPath expression.

Fixes #235.