### PR TITLE
Apparently we need to use /v2 for 2.0.0+ modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ stored in [Cloud Storage][cloud-storage]. An interoperable layer also exists wit
     - Install from source (requires a working Go installation):
 
       ```sh
-      go install github.com/GoogleCloudPlatform/berglas@latest
+      go install github.com/GoogleCloudPlatform/berglas/v2@latest
       ```
 
 1. Export your project ID as an environment variable. The rest of this setup
@@ -353,7 +353,7 @@ Berglas is also a Go library that can be imported in Go projects:
 
 ```go
 import (
-	_ "github.com/GoogleCloudPlatform/berglas/pkg/auto"
+	_ "github.com/GoogleCloudPlatform/berglas/v2/pkg/auto"
 )
 ```
 
@@ -372,7 +372,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/GoogleCloudPlatform/berglas
+module github.com/GoogleCloudPlatform/berglas/v2
 
 go 1.21.4
 

--- a/main.go
+++ b/main.go
@@ -28,9 +28,9 @@ import (
 	"syscall"
 	"text/tabwriter"
 
-	"github.com/GoogleCloudPlatform/berglas/internal/version"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/internal/version"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/auto/auto.go
+++ b/pkg/auto/auto.go
@@ -14,14 +14,14 @@
 
 // Package auto automatically parses berglas references when imported.
 //
-//     import (
-//       _ "github.com/GoogleCloudPlatform/berglas/pkg/auto"
-//     )
+//	import (
+//	  _ "github.com/GoogleCloudPlatform/berglas/v2/pkg/auto"
+//	)
 //
 // Set environment variables on your deployment using the berglas:// prefix in
 // the format:
 //
-//     berglas://<bucket>/<secret>?<params>
+//	berglas://<bucket>/<secret>?<params>
 //
 // - "bucket" is the name of the Google Cloud Storage bucket where secrets
 // are stored
@@ -30,14 +30,13 @@
 //
 // Examples:
 //
-//     berglas://my-bucket/my-secret
-//     berglas://my-bucket/path/to/secret?destination=tempfile
-//     berglas://my-bucket/path/to/secret?destination=/var/foo/bar
+//	berglas://my-bucket/my-secret
+//	berglas://my-bucket/path/to/secret?destination=tempfile
+//	berglas://my-bucket/path/to/secret?destination=/var/foo/bar
 //
 // On init, the package queries the list of configured environment variables
 // against the metadata service. If environment variables match, their values
 // are automatically replaced with the secret value.
-//
 //
 // By default, any errors result in a panic. If you want the function to
 // continue executing even if resolution or communication fails, set the

--- a/pkg/auto/importer.go
+++ b/pkg/auto/importer.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 )
 
 var (

--- a/pkg/berglas/access.go
+++ b/pkg/berglas/access.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	secretspb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 )

--- a/pkg/berglas/berglas.go
+++ b/pkg/berglas/berglas.go
@@ -28,7 +28,7 @@ import (
 	kms "cloud.google.com/go/kms/apiv1"
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/berglas/internal/version"
+	"github.com/GoogleCloudPlatform/berglas/v2/internal/version"
 	"google.golang.org/api/option"
 	storagev1 "google.golang.org/api/storage/v1"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/pkg/berglas/berglas_doc_test.go
+++ b/pkg/berglas/berglas_doc_test.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas"
 )
 
 var (

--- a/pkg/berglas/berglas_test.go
+++ b/pkg/berglas/berglas_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 )
 
 func TestKMSKeyTrimVersion(t *testing.T) {

--- a/pkg/berglas/bootstrap.go
+++ b/pkg/berglas/bootstrap.go
@@ -22,7 +22,7 @@ import (
 
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	"google.golang.org/api/googleapi"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"

--- a/pkg/berglas/create.go
+++ b/pkg/berglas/create.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 
 	secretspb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 )

--- a/pkg/berglas/delete.go
+++ b/pkg/berglas/delete.go
@@ -21,7 +21,7 @@ import (
 
 	secretspb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/api/iterator"
 	grpccodes "google.golang.org/grpc/codes"

--- a/pkg/berglas/grant.go
+++ b/pkg/berglas/grant.go
@@ -21,7 +21,7 @@ import (
 
 	"cloud.google.com/go/iam"
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 )

--- a/pkg/berglas/list.go
+++ b/pkg/berglas/list.go
@@ -23,7 +23,7 @@ import (
 
 	secretspb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	"google.golang.org/api/iterator"
 )
 

--- a/pkg/berglas/read.go
+++ b/pkg/berglas/read.go
@@ -26,7 +26,7 @@ import (
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	secretspb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 )

--- a/pkg/berglas/replace.go
+++ b/pkg/berglas/replace.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 )
 
 // Replace parses a berglas reference and replaces it. See Client.Replace for

--- a/pkg/berglas/resolver.go
+++ b/pkg/berglas/resolver.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 )
 
 // chmodSupported indicates whether the OS supports chmod

--- a/pkg/berglas/revoke.go
+++ b/pkg/berglas/revoke.go
@@ -21,7 +21,7 @@ import (
 
 	"cloud.google.com/go/iam"
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 )

--- a/pkg/berglas/update.go
+++ b/pkg/berglas/update.go
@@ -22,7 +22,7 @@ import (
 	"cloud.google.com/go/iam"
 	secretspb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 )

--- a/pkg/berglas/writer.go
+++ b/pkg/berglas/writer.go
@@ -22,7 +22,7 @@ import (
 
 	"cloud.google.com/go/kms/apiv1/kmspb"
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/berglas/pkg/berglas/logging"
+	"github.com/GoogleCloudPlatform/berglas/v2/pkg/berglas/logging"
 	"google.golang.org/api/googleapi"
 )
 


### PR DESCRIPTION
https://golang.cafe/blog/how-to-upgrade-to-a-major-version-in-go.html

Closes https://github.com/GoogleCloudPlatform/berglas/issues/260