### PR TITLE
Fix official docker container image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ stored in [Cloud Storage][cloud-storage]. An interoperable layer also exists wit
     - Install a pre-compiled binary for your operating system from the [latest
       releases](releases).
 
-    - Use an [official Docker container](us-docker.pkg.dev/berglas/berglas/berglas):
+    - Use an [official Docker container](https://us-docker.pkg.dev/berglas/berglas/berglas):
 
       ```text
       docker run -it us-docker.pkg.dev/berglas/berglas/berglas


### PR DESCRIPTION
Setting the link directly makes it a relative link, which ends up pointing to a non-existing file in this repo.

We need to make this an absolute link, so that the GCP redirection can point to the artifact registry.