### PR TITLE
Use errors.Is to compare errors

### DIFF
--- a/pkg/berglas/grant.go
+++ b/pkg/berglas/grant.go
@@ -16,6 +16,7 @@ package berglas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -170,7 +171,7 @@ func (c *Client) storageGrant(ctx context.Context, i *StorageGrantRequest) error
 
 	objHandle := c.storageClient.Bucket(bucket).Object(object)
 	attrs, err := objHandle.Attrs(ctx)
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		return errSecretDoesNotExist
 	}
 	if err != nil {

--- a/pkg/berglas/read.go
+++ b/pkg/berglas/read.go
@@ -17,6 +17,7 @@ package berglas
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -199,7 +200,7 @@ func (c *Client) storageRead(ctx context.Context, i *StorageReadRequest) (*Secre
 		Object(object).
 		Generation(generation).
 		Attrs(ctx)
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		return nil, errSecretDoesNotExist
 	}
 	if err != nil {
@@ -221,7 +222,7 @@ func (c *Client) storageRead(ctx context.Context, i *StorageReadRequest) (*Secre
 		Object(object).
 		Generation(generation).
 		NewReader(ctx)
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		return nil, fmt.Errorf("secret object not found")
 	}
 	if err != nil {

--- a/pkg/berglas/revoke.go
+++ b/pkg/berglas/revoke.go
@@ -16,6 +16,7 @@ package berglas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -170,7 +171,7 @@ func (c *Client) storageRevoke(ctx context.Context, i *StorageRevokeRequest) err
 
 	objHandle := c.storageClient.Bucket(bucket).Object(object)
 	attrs, err := objHandle.Attrs(ctx)
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		return errSecretDoesNotExist
 	}
 	if err != nil {

--- a/pkg/berglas/update.go
+++ b/pkg/berglas/update.go
@@ -16,6 +16,7 @@ package berglas
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 
@@ -232,8 +233,7 @@ func (c *Client) storageUpdate(ctx context.Context, i *StorageUpdateRequest) (*S
 		Bucket(bucket).
 		Object(object).
 		Attrs(ctx)
-	switch err {
-	case nil:
+	if err == nil {
 		logger = logger.With(
 			"existing.bucket", attrs.Bucket,
 			"existing.name", attrs.Name,
@@ -309,7 +309,7 @@ func (c *Client) storageUpdate(ctx context.Context, i *StorageUpdateRequest) (*S
 			return nil, fmt.Errorf("failed to update Storage IAM policy for %s: %w", object, err)
 		}
 		return secret, nil
-	case storage.ErrObjectNotExist:
+	} else if errors.Is(err, storage.ErrObjectNotExist) {
 		logger.DebugContext(ctx, "secret does not exist")
 
 		if !createIfMissing {
@@ -333,7 +333,7 @@ func (c *Client) storageUpdate(ctx context.Context, i *StorageUpdateRequest) (*S
 			return nil, fmt.Errorf("failed to update secret: %w", err)
 		}
 		return secret, nil
-	default:
+	} else {
 		return nil, fmt.Errorf("failed to fetch existing secret: %w", err)
 	}
 }


### PR DESCRIPTION
With cloud.google.com/go/storage v1.51.0, the errors are being wrapped with fmt.Errorf, leading to the following error message:

failed to fetch existing secret: storage: object doesn't exist: