### PR TITLE
Fix multi-arch images: non-amd64 slices ship an amd64 rootfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM alpine:latest AS builder
+FROM alpine:latest
 
 RUN apk --no-cache add ca-certificates && \
   update-ca-certificates


### PR DESCRIPTION
## Problem

Every published multi-arch berglas container image has broken non-amd64 slices: the manifest list and image config claim `arm64`, but the **entire Alpine rootfs is x86-64** — only the `berglas` binary matches the target platform. On real arm64 hosts (e.g. GKE Axion/C4A nodes, where no emulation exists), anything that execs the image's shell fails:

```
$ kubectl logs <pod> -c install-berglas
exec /bin/sh: exec format error
```

The common Kubernetes install pattern (an init container running `sh -c "cp /bin/berglas /berglas/bin/"`) is therefore unusable on arm64. Verified on `1.0.3`, `2.0.2`, `2.0.8`, and `latest` in all three regional registries by extracting the arm64 child layers:

| file in arm64 slice | actual ELF arch |
|---|---|
| `/bin/berglas` | aarch64 ✅ |
| `/bin/busybox` (→ `sh`, `cp`, …) | **x86-64** ❌ (interpreter `/lib/ld-musl-x86_64.so.1`) |

Easy repro on an arm64 machine (Docker Desktop's Rosetta masks the failure but reveals the mismatch):

```
$ docker run --rm --entrypoint sh us-docker.pkg.dev/berglas/berglas/berglas:2.0.8 -c 'uname -m'
x86_64        # inside the image whose config says "architecture": "arm64"
```

## Root cause

The Dockerfile's only stage is pinned to the build host's platform:

```dockerfile
FROM --platform=$BUILDPLATFORM alpine:latest AS builder
```

`--platform=$BUILDPLATFORM` is the cross-compilation idiom for *builder* stages in multi-stage Dockerfiles — but there is no second stage, so the "builder" IS the published image. goreleaser's buildx invocation (`--platform=linux/arm64`) correctly stamps the config architecture and picks up the cross-compiled binary from the build context, while the base filesystem silently stays amd64.

## Fix

Drop the `--platform` pin (and the misleading `AS builder` name) so buildx resolves `alpine:latest` for each target platform. No goreleaser or workflow changes needed: `release.yml` already runs `docker/setup-qemu-action`, so the `apk` RUN steps work under emulation for the arm64 build.

## Validation

Built with release fidelity (binary cross-compiled from this repo with `CGO_ENABLED=0 GOOS=linux GOARCH=<arch>`, placed in the context like goreleaser does, `docker buildx build --platform linux/<arch>`):

| platform | `sh -c 'uname -m'` | `/bin/busybox` | `/bin/berglas` |
|---|---|---|---|
| linux/arm64 | `aarch64` (was `x86_64`) | ELF aarch64 | ELF aarch64 |
| linux/amd64 | `x86_64` | ELF x86-64 | ELF x86-64 |

`ENTRYPOINT` behavior is unchanged; amd64 output is equivalent to today's images.

Note: previously published tags remain broken — arm64 users need a release cut after this lands.
